### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/Scripts/localize.py
+++ b/Scripts/localize.py
@@ -44,7 +44,7 @@ class LocalizedFile():
             self.read_from_file(fname)
 
     def read_from_file(self, fname=None):
-        fname = self.fname if fname == None else fname
+        fname = self.fname if fname is None else fname
         try:
             f = open(fname, encoding='utf_16', mode='r')
         except:
@@ -80,7 +80,7 @@ class LocalizedFile():
         f.close()
 
     def save_to_file(self, fname=None):
-        fname = self.fname if fname == None else fname
+        fname = self.fname if fname is None else fname
         try:
             f = open(fname, encoding='utf_16', mode='w')
         except:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:WordPress-iOS?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:WordPress-iOS?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
